### PR TITLE
Bugfixes

### DIFF
--- a/src/Aura/Marshal/Entity/GenericEntity.php
+++ b/src/Aura/Marshal/Entity/GenericEntity.php
@@ -22,5 +22,4 @@ use Aura\Marshal\Data;
 class GenericEntity extends Data
 {
     use MagicArrayAccessTrait;
-
 }

--- a/src/Aura/Marshal/Entity/GenericEntity.php
+++ b/src/Aura/Marshal/Entity/GenericEntity.php
@@ -22,4 +22,5 @@ use Aura\Marshal\Data;
 class GenericEntity extends Data
 {
     use MagicArrayAccessTrait;
+
 }

--- a/src/Aura/Marshal/Manager.php
+++ b/src/Aura/Marshal/Manager.php
@@ -143,9 +143,9 @@ class Manager
      * 
      */
     public function __construct(
-        TypeBuilder     $type_builder,
+        TypeBuilder $type_builder,
         RelationBuilder $relation_builder,
-        array           $types = []
+        array $types = []
     ) {
         $this->type_builder     = $type_builder;
         $this->relation_builder = $relation_builder;

--- a/src/Aura/Marshal/Type/GenericType.php
+++ b/src/Aura/Marshal/Type/GenericType.php
@@ -95,7 +95,7 @@ class GenericType extends Data
      * @var array
      * 
      */
-    protected $index_new;
+    protected $index_new = [];
 
     /**
      * 

--- a/tests/Aura/Marshal/TypeTest.php
+++ b/tests/Aura/Marshal/TypeTest.php
@@ -353,6 +353,15 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $actual = $this->type->getChangedEntities();
         $this->assertSame($expect, $actual);
     }
+
+    public function testGetChangedEntities_empty()
+    {
+        $data = $this->loadTypeWithPosts();
+        $expect = [];
+
+        $actual = $this->type->getChangedEntities();
+        $this->assertSame($expect, $actual);
+    }
     
     public function testGetNewEntities()
     {
@@ -362,6 +371,14 @@ class TypeTest extends \PHPUnit_Framework_TestCase
             $this->type->newEntity(['fake_field' => 102]),
             $this->type->newEntity(['fake_field' => 105]),
         ];
+        $actual = $this->type->getNewEntities();
+        $this->assertSame($expect, $actual);
+    }
+
+    public function testGetNewEntities_empty()
+    {
+        $data = $this->loadTypeWithPosts();
+        $expect = [];
         $actual = $this->type->getNewEntities();
         $this->assertSame($expect, $actual);
     }


### PR DESCRIPTION
#### Bugfix

Fixed a bug where 

``` php
Aura\Marshal\Type\GenericType->$index_new
```

was not properly initialized.
#### New Tests

Added tests for empty Results of 

``` php
Aura\Marshal\Type\GenericType->getChangedEntities() 
```

and 

``` php
Aura\Marshal\Type\GenericType->getNewEntities()
```
##### Fixed Code Style Bugs
