### PR TITLE
Added Functionality to delete Entities

### DIFF
--- a/src/Aura/Marshal/Type/GenericType.php
+++ b/src/Aura/Marshal/Type/GenericType.php
@@ -95,7 +95,7 @@ class GenericType extends Data
      * @var array
      * 
      */
-    protected $index_new;
+    protected $index_new = [];
 
     /**
      *

--- a/src/Aura/Marshal/Type/GenericType.php
+++ b/src/Aura/Marshal/Type/GenericType.php
@@ -98,6 +98,17 @@ class GenericType extends Data
     protected $index_new;
 
     /**
+     *
+     * An index of all entities deleted via deleteEntity(). The format is:
+     *
+     *      $index_delete[] = $identity_value
+     *
+     * @var array
+     *
+     */
+    protected $index_deleted = [];
+
+    /**
      * 
      * An object store of the initial data for entity in the IdentityMap.
      * 
@@ -747,6 +758,57 @@ class GenericType extends Data
     }
 
     /**
+     *
+     * Delete an Entity
+     *
+     * First deletes the Entity from all Indexes, then unsets the Entity itself.
+     * Add the Entities identity_value to the index_deleted.
+     *
+     *
+     * @param $identity_value int identity_value of the Entity to be deleted
+     *
+     * @return bool success
+     */
+    public function deleteEntity($identity_value)
+    {
+        // if the entity is not in the identity index, exit early
+        if (! isset($this->index_identity[$identity_value])) {
+            return false;
+        }
+
+        // look up the sequential offset for the identity value
+        $offset = $this->index_identity[$identity_value];
+        // get the Entity
+        $entity = $this->offsetGet($offset);
+
+        // add Entities identity_value to the deleted Index
+        $this->index_deleted[] = $identity_value;
+
+        // delete the Entity from the Identity Index
+        unset($this->index_identity[$identity_value]);
+
+        // get Index Fields
+        $index_fields = array_keys($this->index_fields);
+
+        // loop trough indicies and delete offsets of this Entity
+        foreach ($index_fields as $field) {
+            $value = $entity->$field;
+            // find index of the offset
+            $offset_idx = array_search($offset, $this->index_fields[$field][$value]);
+            if ($offset === false) {
+                continue;
+            } else {
+                // remove the offset from the index, preserving index integrity
+                array_splice($this->index_fields[$field][$value], $offset_idx, 1);
+            }
+        }
+
+        //unset the Entity
+        $this->offsetUnset($offset);
+        return true;
+    }
+
+    /**
      * 
      * Returns an array of all entities in the IdentityMap that have been 
      * modified.
@@ -781,6 +843,17 @@ class GenericType extends Data
             $list[] = $this->data[$offset];
         }
         return $list;
+    }
+
+    /**
+     * Returns an array of identity_values from entities that were deleted
+     * using `deleteEntity()`.
+     *
+     * @return array
+     */
+    public function getDeletedEntitiesIds()
+    {
+        return $this->index_deleted;
     }
     
     /**

--- a/tests/Aura/Marshal/TypeTest.php
+++ b/tests/Aura/Marshal/TypeTest.php
@@ -448,4 +448,177 @@ class TypeTest extends \PHPUnit_Framework_TestCase
             $collection
         );
     }
+
+    public function testDelete_none()
+    {
+        $this->loadTypeWithPosts();
+
+        $this->assertSame([], $this->type->getDeletedEntitiesIds());
+    }
+
+    public function testDelete_single()
+    {
+        $this->loadTypeWithPosts();
+
+        $this->assertTrue($this->type->deleteEntity(1));
+
+        $this->assertSame([1], $this->type->getDeletedEntitiesIds());
+    }
+
+    public function testDelete_many()
+    {
+        $this->loadTypeWithPosts();
+
+        $this->assertTrue($this->type->deleteEntity(1));
+        $this->assertTrue($this->type->deleteEntity(2));
+        $this->assertTrue($this->type->deleteEntity(3));
+
+        $this->assertSame([1, 2, 3], $this->type->getDeletedEntitiesIds());
+    }
+
+    public function testDeleteNonExistent()
+    {
+        $this->loadTypeWithPosts();
+
+        $this->assertFalse($this->type->deleteEntity(99999));
+    }
+
+    public function testDeleteAndGet()
+    {
+        $this->loadTypeWithPosts();
+        $this->assertTrue($this->type->deleteEntity(1));
+
+        $this->assertNull($this->type->getEntity(1));
+    }
+
+    public function testDeleteAndDeleteAgain()
+    {
+        $this->loadTypeWithPosts();
+        $this->assertTrue($this->type->deleteEntity(1));
+        $this->assertFalse($this->type->deleteEntity(1));
+    }
+
+    public function testDeleteEmpty()
+    {
+        $this->assertFalse($this->type->deleteEntity(1));
+    }
+
+    public function testDeleteAndGetCollectionByIndex_first()
+    {
+        $data = $this->loadTypeWithPosts();
+
+        $expect = [
+            (object) $data[1],
+            (object) $data[2]
+        ];
+
+        $this->assertTrue($this->type->deleteEntity(1));
+
+        $collection = $this->type->getCollectionByField('author_id', 1);
+
+        foreach ($collection as $offset => $actual) {
+            $this->assertSame($expect[$offset]->id, $actual->id);
+            $this->assertSame($expect[$offset]->author_id, $actual->author_id);
+            $this->assertSame($expect[$offset]->body, $actual->body);
+            $this->assertSame($expect[$offset]->fake_field, $actual->fake_field);
+        }
+    }
+
+    public function testDeleteAndGetCollectionByIndex_second()
+    {
+        $data = $this->loadTypeWithPosts();
+
+        $expect = [
+            (object) $data[0],
+            (object) $data[2]
+        ];
+
+        $this->assertTrue($this->type->deleteEntity(2));
+
+        $collection = $this->type->getCollectionByField('author_id', 1);
+
+        foreach ($collection as $offset => $actual) {
+            $this->assertSame($expect[$offset]->id, $actual->id);
+            $this->assertSame($expect[$offset]->author_id, $actual->author_id);
+            $this->assertSame($expect[$offset]->body, $actual->body);
+            $this->assertSame($expect[$offset]->fake_field, $actual->fake_field);
+        }
+    }
+
+    public function testDeleteAndGetCollectionByField_first()
+    {
+        $data = $this->loadTypeWithPosts();
+
+        $expect = [
+            (object) $data[4]
+        ];
+
+        $this->assertTrue($this->type->deleteEntity(4));
+
+        $collection = $this->type->getCollectionByField('fake_field', 88);
+
+        foreach ($collection as $offset => $actual) {
+            $this->assertSame($expect[$offset]->id, $actual->id);
+            $this->assertSame($expect[$offset]->author_id, $actual->author_id);
+            $this->assertSame($expect[$offset]->body, $actual->body);
+            $this->assertSame($expect[$offset]->fake_field, $actual->fake_field);
+        }
+    }
+
+    public function testDeleteAndGetCollectionByField_second()
+    {
+        $data = $this->loadTypeWithPosts();
+
+        $expect = [
+            (object) $data[0],
+            (object) $data[2],
+        ];
+
+        $this->assertTrue($this->type->deleteEntity(2));
+
+        $collection = $this->type->getCollectionByField('fake_field', 69);
+
+        foreach ($collection as $offset => $actual) {
+            $this->assertSame($expect[$offset]->id, $actual->id);
+            $this->assertSame($expect[$offset]->author_id, $actual->author_id);
+            $this->assertSame($expect[$offset]->body, $actual->body);
+            $this->assertSame($expect[$offset]->fake_field, $actual->fake_field);
+        }
+    }
+
+    public function testDeleteAndGetCollectionByField_many()
+    {
+        $data = $this->loadTypeWithPosts();
+
+        $expect = [
+            (object) $data[0],
+            (object) $data[2],
+            (object) $data[4]
+        ];
+
+        $this->assertTrue($this->type->deleteEntity(2));
+        $this->assertTrue($this->type->deleteEntity(4));
+
+        $collection = $this->type->getCollectionByField('fake_field', [88, 69]);
+
+        foreach ($collection as $offset => $actual) {
+            $this->assertSame($expect[$offset]->id, $actual->id);
+            $this->assertSame($expect[$offset]->author_id, $actual->author_id);
+            $this->assertSame($expect[$offset]->body, $actual->body);
+            $this->assertSame($expect[$offset]->fake_field, $actual->fake_field);
+        }
+    }
+
+    public function testDeleteAll()
+    {
+        $data = $this->loadTypeWithPosts();
+
+        foreach ($data as $post) {
+            $this->assertTrue($this->type->deleteEntity($post['id']));
+        }
+
+        $this->assertSame(0, $this->type->count());
+
+        $this->assertNull($this->type->getEntity(1));
+    }
 }


### PR DESCRIPTION
### deleteEntity()

Added 

``` php
Aura\Marshal\Type\GenericType->deleteEntity($identity_value)
```

The Function takes the identity_value of the Entity to be deleted as parameter and deletes it from all indicies.
### getDeletedEntitiesIds()

Added

``` php
Aura\Marshal\Type\GenericType->getDeletedEntitiesIds()
```

The function takes no arguments and returns an array of identity_values of Entities deleted using deleteEntity()
### Tests

Added several test for the Deletion Functionality
