### PR TITLE
Change GenericEntity to properly be converted to an array via iterator_to_array

### DIFF
--- a/src/Aura/Marshal/Entity/GenericEntity.php
+++ b/src/Aura/Marshal/Entity/GenericEntity.php
@@ -1,25 +1,39 @@
 <?php
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Marshal
- * 
+ *
  * @license http://opensource.org/licenses/bsd-license.php BSD
- * 
+ *
  */
 namespace Aura\Marshal\Entity;
 
 use Aura\Marshal\Data;
 
 /**
- * 
+ *
  * Represents a single entity.
- * 
+ *
  * @package Aura.Marshal
- * 
+ *
  */
 class GenericEntity extends Data
 {
     use MagicArrayAccessTrait;
+
+    /**
+     *
+     * ArrayAccess: get a key value.
+     *
+     * @param int|string $key The requested key.
+     *
+     * @return mixed
+     *
+     */
+    public function offsetGet($key)
+    {
+        return $this->$key;
+    }
 }

--- a/src/Aura/Marshal/Entity/MagicArrayAccessTrait.php
+++ b/src/Aura/Marshal/Entity/MagicArrayAccessTrait.php
@@ -1,47 +1,46 @@
 <?php
 /**
- * 
+ *
  * This file is part of the Aura project for PHP.
- * 
+ *
  * @package Aura.Marshal
- * 
+ *
  * @license http://opensource.org/licenses/bsd-license.php BSD
- * 
+ *
  */
 namespace Aura\Marshal\Entity;
 
 use Aura\Marshal\Lazy\LazyInterface;
 
 /**
- * 
+ *
  * Use this trait for magic __get(), __set(), __isset(), and __unset() on any
  * entity class that implements ArrayAccess for its fields.
- * 
+ *
  * @package Aura.Marshal
- * 
+ *
  */
 trait MagicArrayAccessTrait
 {
     /**
-     * 
+     *
      * Calls ArrayAccess::offsetGet() to get a field value; converts Lazy
      * objects for related entities and collections in place.
-     * 
+     *
      * @param string $field The field name to get.
-     * 
+     *
      * @return mixed The field value.
-     * 
+     *
      */
     public function __get($field)
     {
         // get the field value
-        $value = $this->offsetGet($field);
+        $value = $this->data[$field];
 
         // is it a Lazy placeholder?
         if ($value instanceof LazyInterface) {
             // replace the Lazy placeholder with the real object
             $value = $value->get($this);
-            $this->offsetSet($field, $value);
         }
 
         // done!
@@ -49,15 +48,15 @@ trait MagicArrayAccessTrait
     }
 
     /**
-     * 
+     *
      * Calls ArrayAccess::offsetSet() to set a field value.
-     * 
+     *
      * @param string $field The field name to get.
-     * 
+     *
      * @param mixed $value Set the field to this value.
-     * 
+     *
      * @return void
-     * 
+     *
      */
     public function __set($field, $value)
     {
@@ -65,13 +64,13 @@ trait MagicArrayAccessTrait
     }
 
     /**
-     * 
+     *
      * Calls ArrayAccess::offsetExists() to see if a field is set.
-     * 
+     *
      * @param string $field The field name to check.
-     * 
+     *
      * @return bool
-     * 
+     *
      */
     public function __isset($field)
     {
@@ -79,13 +78,13 @@ trait MagicArrayAccessTrait
     }
 
     /**
-     * 
+     *
      * Calls ArrayAccess::offsetUnset() to unset a field.
-     * 
+     *
      * @param string $field The field name to unset.
-     * 
+     *
      * @return void
-     * 
+     *
      */
     public function __unset($field)
     {

--- a/tests/Aura/Marshal/RelationTest.php
+++ b/tests/Aura/Marshal/RelationTest.php
@@ -25,14 +25,14 @@ class RelationTest extends \PHPUnit_Framework_TestCase
         $type_builder       = new TypeBuilder;
         $relation_builder   = new RelationBuilder;
         $types              = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $this->manager      = new Manager($type_builder, $relation_builder, $types);
         $data               = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_data.php';
         foreach ($this->manager->getTypes() as $type) {
             $obj = $this->manager->{$type}->load($data[$type]);
         }
     }
-    
+
     /**
      * Tears down the fixture, for example, closes a network connection.
      * This method is called after a test is executed.
@@ -41,112 +41,112 @@ class RelationTest extends \PHPUnit_Framework_TestCase
     {
         parent::tearDown();
     }
-    
+
     public function testNoRelationship()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['relationship'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testNoForeignType()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['foreign_type'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testNoNativeField()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['native_field'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testNoForeignField()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['foreign_field'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testNoThroughType()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['through_type'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testNoThroughNativeField()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['through_native_field'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testNoThroughForeignField()
     {
         $type_builder     = new TypeBuilder;
         $relation_builder = new RelationBuilder;
         $types            = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_types.php';
-        
+
         $types['posts']['relation_names']['tags']['through_foreign_field'] = null;
-        
+
         $this->manager = new Manager($type_builder, $relation_builder, $types);
         $this->setExpectedException('Aura\Marshal\Exception');
         $this->manager->posts;
     }
-    
+
     public function testGetForeignType()
     {
         $relation = $this->manager->posts->getRelation('author');
         $actual = $relation->getForeignType();
         $this->assertSame('authors', $actual);
     }
-    
+
     public function testBelongsTo()
     {
         $post = $this->manager->posts->getEntity(1);
         $this->assertSame('1', $post->author->id);
         $this->assertSame('Anna', $post->author->name);
     }
-    
+
     public function testHasOne()
     {
         $post = $this->manager->posts->getEntity(1);
@@ -154,40 +154,50 @@ class RelationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('1', $post->meta->post_id);
         $this->assertSame('meta 1', $post->meta->data);
     }
-    
+
     public function testHasMany()
     {
         $post = $this->manager->posts->getEntity(5);
         $this->assertSame(3, count($post->comments));
-        
+
         $data  = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_data.php';
         $expect = [
             $data['comments'][3],
             $data['comments'][4],
             $data['comments'][5],
         ];
-        
+
         foreach ($post->comments as $offset => $comment) {
             $this->assertSame($expect[$offset]['id'], $comment->id);
             $this->assertSame($expect[$offset]['post_id'], $comment->post_id);
             $this->assertSame($expect[$offset]['body'], $comment->body);
         }
     }
-    
+
     public function testHasManyThrough()
     {
         $post = $this->manager->posts->getEntity(3);
         $this->assertSame(2, count($post->tags));
-        
+
         $data  = include __DIR__ . DIRECTORY_SEPARATOR . 'fixture_data.php';
         $expect = [
             $data['tags'][2],
             $data['tags'][0],
         ];
-        
+
         foreach ($post->tags as $offset => $tag) {
             $this->assertSame($expect[$offset]['id'], $tag->id);
             $this->assertSame($expect[$offset]['name'], $tag->name);
         }
+    }
+
+    public function testIteratorToArrayEntityHasRelationships()
+    {
+        $posts = $this->manager->posts->getCollection($this->manager->posts->getIdentityValues());
+        $postsArray = iterator_to_array($posts);
+
+        $this->assertCount(3, $postsArray[0]['comments']);
+        $this->assertCount(2, $postsArray[0]['tags']);
+        $this->assertEquals('Anna', $postsArray[0]['author']['name']);
     }
 }


### PR DESCRIPTION
This allows entities to be properly converted to arrays using iterator_to_array.

The iterator_to_array method is used in Twig, so this PR allows aura.marshal collections to be properly filled when passed into twig templates.
