### PR TITLE
Move conversion of Lazy Objects to GenericEntity. This allows for proper/expected usage with iterator_to_array for relationships

### DIFF
--- a/src/Aura/Marshal/Entity/GenericEntity.php
+++ b/src/Aura/Marshal/Entity/GenericEntity.php
@@ -22,4 +22,28 @@ use Aura\Marshal\Data;
 class GenericEntity extends Data
 {
     use MagicArrayAccessTrait;
+
+    /**
+     *
+     * ArrayAccess: get a key value.
+     *
+     * @param int|string $key The requested key.
+     *
+     * @return mixed
+     *
+     */
+    public function offsetGet($field)
+    {
+        // get the field value
+        $value = $this->data[$field];
+
+        // is it a Lazy placeholder?
+        if ($value instanceof LazyInterface) {
+            // replace the Lazy placeholder with the real object
+            $value = $value->get($this);
+        }
+
+        // done!
+        return $value;
+    }
 }

--- a/tests/Aura/Marshal/RelationTest.php
+++ b/tests/Aura/Marshal/RelationTest.php
@@ -190,4 +190,14 @@ class RelationTest extends \PHPUnit_Framework_TestCase
             $this->assertSame($expect[$offset]['name'], $tag->name);
         }
     }
+
+    public function testIteratorToArrayEntityHasRelationships()
+    {
+        $posts = $this->manager->posts->getCollection($this->manager->posts->getIdentityValues());
+        $postsArray = iterator_to_array($posts);
+
+        $this->assertCount(3, $postsArray[0]->comments);
+        $this->assertCount(2, $postsArray[0]->tags);
+        $this->assertEquals('Anna', $postsArray[0]->author->name);
+    }
 }


### PR DESCRIPTION
Prior to this commit anytime a user used iterator_to_array, it would not properly convert relationships. With this modification this is possible. Twig uses iterator_to_array for all iterators, so now Marshal Collections will be properly converted.
