### PR TITLE
add v2 config psr-4 autoload in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
     "autoload": {
         "psr-0": {
             "Aura\\Marshal": "src/"
+        },
+        "psr-4": {
+            "Aura\\Marshal\\_Config\\": "config/"
         }
     },
     "extra": {


### PR DESCRIPTION
An error occured after composer update.

PHP Fatal error: Uncaught exception 'ReflectionException' with message 'Class Aura\Marshal_Config\Common does not exist'

So add autoload psr-4 config.

(PR again. As I checkout "master" not "develop")
