### PR TITLE
Add missing interface to GenericCollection

### DIFF
--- a/src/Collection/GenericCollection.php
+++ b/src/Collection/GenericCollection.php
@@ -11,6 +11,7 @@
 namespace Aura\Marshal\Collection;
 
 use Aura\Marshal\Data;
+use Aura\Marshal\ToArrayInterface;
 use Aura\Marshal\ToArrayTrait;
 
 /**

--- a/src/Collection/GenericCollection.php
+++ b/src/Collection/GenericCollection.php
@@ -21,7 +21,7 @@ use Aura\Marshal\ToArrayTrait;
  * @package Aura.Marshal
  *
  */
-class GenericCollection extends Data
+class GenericCollection extends Data implements ToArrayInterface
 {
     use ToArrayTrait;
 


### PR DESCRIPTION
toArray() does not work properly without this.