### PR TITLE
Support PHP 8.5

### DIFF
--- a/src/Type/GenericType.php
+++ b/src/Type/GenericType.php
@@ -437,7 +437,7 @@ class GenericType extends Data
 
         // get the entity and retain initial data
         $entity = end($this->data);
-        $this->initial_data->attach($entity, $initial_data);
+        $this->initial_data[$entity] = $initial_data;
 
         // build indexes by offset
         $offset = key($this->data);


### PR DESCRIPTION
Method SplObjectStorage::attach() is deprecated since PHP 8.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data storage mechanism for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->