### PR TITLE
Add PHP version 8.5 to CI workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,6 +23,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
Add 8.5 to CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded continuous integration testing to include PHP 8.5 verification, ensuring broader runtime compatibility assessment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->